### PR TITLE
git_hooks_path Path.expand

### DIFF
--- a/lib/law.ex
+++ b/lib/law.ex
@@ -3,7 +3,7 @@ defmodule Law do
   Documentation for Law.
   """
   project_top_path = Mix.Project.deps_path() |> Path.join("..")
-  git_hooks_path = Path.join(project_top_path, ".git/hooks")
+  git_hooks_path = Path.join(project_top_path, ".git/hooks") |> Path.expand()
   case File.exists?(git_hooks_path) do
     true ->
       pre_commit_hook_path = Path.join(git_hooks_path, "pre-commit")


### PR DESCRIPTION
looks like `File.exists` does not like `../` in paths in my mac at least.

before:
```
❯ mix compile
Compiling 3 files (.ex)

== Compilation error in file lib/law.ex ==
** (RuntimeError) It seems path /Users/user123/law/deps/../.git/hooks is not exist. To keep the Law, your Elixir project should be in git repository.
    lib/law.ex:18: (module)
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
```

after:
```
❯ mix compile
Compiling 3 files (.ex)
pre-commit hook /Users/user123/law/.git/hooks/pre-commit already exists, do nothing
Generated law app
```